### PR TITLE
Resolves #76 

### DIFF
--- a/src/single-spa-react.js
+++ b/src/single-spa-react.js
@@ -20,7 +20,9 @@ const defaultOpts = {
   parcelCanUpdate: true, // by default, allow parcels created with single-spa-react to be updated
 };
 
-export default function singleSpaReact(userOpts) {
+export default singleSpaReact;
+
+export function singleSpaReact(userOpts) {
   if (typeof userOpts !== "object") {
     throw new Error(`single-spa-react requires a configuration object`);
   }


### PR DESCRIPTION
With named export the following syntax works the same in both cases (regular and external dependency), while backward compatibility remains.
```js
import {singleSpaReact} from 'single-spa-react';

const lifecycles = singleSpaReact({
  React,
  ReactDOM,
  rootComponent
});
```