### PR TITLE
Decreasing tarball size published to npm.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-# not lib
-coverage

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
       "require": "./lib/cjs/parcel.cjs"
     }
   },
+  "files": [
+    "lib",
+    "README.md"
+  ],
   "scripts": {
     "build": "rollup -c",
     "test": "jest --config jest.json",


### PR DESCRIPTION
Using `files` in the package.json is easier than npmignore to get the files you want since it's an include list instead of an exclude list. This reduced the tarball created by `npm pack` from 24kb to 15kb