### PR TITLE
Removing dead code and adding tests

### DIFF
--- a/src/single-spa-react.js
+++ b/src/single-spa-react.js
@@ -231,13 +231,6 @@ function reactDomRender({ opts, elementToRender, domElement, whenFinished }) {
     );
   }
 
-  if (opts.renderType === "createBlockingRoot") {
-    return opts.ReactDOM.createBlockingRoot(domElement).render(
-      elementToRender,
-      whenFinished
-    );
-  }
-
   if (opts.renderType === "hydrate") {
     return opts.ReactDOM.hydrate(elementToRender, domElement, whenFinished);
   }

--- a/src/single-spa-react.test.js
+++ b/src/single-spa-react.test.js
@@ -42,6 +42,22 @@ describe("single-spa-react", () => {
             }),
           };
         }),
+        createBlockingRoot: jest.fn((domEl) => {
+          return {
+            render: jest.fn((reactEl, cbk) => {
+              cbk();
+              return componentInstance;
+            }),
+          };
+        }),
+        unstable_createBlockingRoot: jest.fn((domEl) => {
+          return {
+            render: jest.fn((reactEl, cbk) => {
+              cbk();
+              return componentInstance;
+            }),
+          };
+        }),
         unmountComponentAtNode: jest.fn(),
       });
 
@@ -190,6 +206,48 @@ describe("single-spa-react", () => {
         expect(React.createElement.mock.calls[0][1]).toEqual(props);
         expect(ReactDOM.unstable_createRoot).toHaveBeenCalled();
         expect(ReactDOM.unstable_createRoot.mock.calls[0][0]).toEqual(
+          domElement
+        );
+        expect(createRootRender.mock.calls[0][0]).toEqual(createdReactElement);
+        expect(typeof createRootRender.mock.calls[0][1]).toEqual("function");
+        return lifecycles.unmount(props);
+      })
+      .then(() => {
+        expect(ReactDOM.unmountComponentAtNode).toHaveBeenCalledWith(
+          domElement
+        );
+      });
+  });
+
+  it(`mounts and unmounts a React component with a 'renderType' of 'createBlockingRoot'`, () => {
+    const props = { why: "hello" };
+    const lifecycles = singleSpaReact({
+      React,
+      ReactDOM,
+      rootComponent,
+      domElementGetter,
+      renderType: "createBlockingRoot",
+    });
+
+    const createRootRender = jest.fn();
+    ReactDOM.createBlockingRoot.mockImplementation((domEl) => {
+      return {
+        render: createRootRender.mockImplementation((reactEl, cbk) => {
+          cbk();
+          return componentInstance;
+        }),
+      };
+    });
+
+    return lifecycles
+      .bootstrap()
+      .then(() => lifecycles.mount(props))
+      .then(() => {
+        expect(React.createElement).toHaveBeenCalled();
+        expect(React.createElement.mock.calls[0][0]).toEqual(rootComponent);
+        expect(React.createElement.mock.calls[0][1]).toEqual(props);
+        expect(ReactDOM.createBlockingRoot).toHaveBeenCalled();
+        expect(ReactDOM.createBlockingRoot.mock.calls[0][0]).toEqual(
           domElement
         );
         expect(createRootRender.mock.calls[0][0]).toEqual(createdReactElement);


### PR DESCRIPTION
createBlockingRoot is now implemented twice, after #94. This PR cleans that up.