### PR TITLE
Fix bug with Parcels relying on SingleSpaContext. Resolves #105.

### DIFF
--- a/src/single-spa-react.js
+++ b/src/single-spa-react.js
@@ -5,6 +5,22 @@
 // React context that gives any react component the single-spa props
 export let SingleSpaContext = null;
 
+// This try/catch exists mostly to prevent rollup from thinking that SingleSpaContext
+// is null and then doing optimizations in parcel.js that cause bugs.
+// See https://github.com/single-spa/single-spa-react/issues/105
+
+try {
+  // single-spa-react is usable as a global script, as a systemjs module, and other
+  // situations where require() is unavailable. This is why we require the user to
+  // pass in opts.React and opts.ReactDOM - to avoid the mess of "how do i properly load react".
+  // However, in situations where require() is available, we can use it this way to create
+  // the react context. The try/catch defensiveness keeps single-spa-react working in
+  // as many situations as possible.
+  SingleSpaContext = require("react").createContext();
+} catch {
+  // ignore
+}
+
 const defaultOpts = {
   // required opts
   React: null,


### PR DESCRIPTION
See #105. Rollup incorrectly is replacing all instances of `SingleSpaContext` with `null` inside of the output `parcel.js` bundle. We set the value inside of a function, which is apparently beyond what rollup's replacement algorithm can detect.

Adding the try/catch is a way of letting rollup know that the value isn't null, without setting it to a dummy value that could break things for users who do use `SingleSpaContext` as an API and expect it to either be null or a valid react context.

I'm open to other suggestions about how to fix this.