### PR TITLE
types: add props to loadRootComponent

### DIFF
--- a/types/single-spa-react.d.ts
+++ b/types/single-spa-react.d.ts
@@ -10,7 +10,7 @@ export interface SingleSpaReactOpts<RootComponentProps> {
   rootComponent?:
     | React.ComponentClass<RootComponentProps, any>
     | React.FunctionComponent<RootComponentProps>;
-  loadRootComponent?: () => Promise<
+  loadRootComponent?: (props: RootComponentProps) => Promise<
     | React.ComponentClass<RootComponentProps, any>
     | React.FunctionComponent<RootComponentProps>
   >;

--- a/types/single-spa-react.d.ts
+++ b/types/single-spa-react.d.ts
@@ -10,7 +10,9 @@ export interface SingleSpaReactOpts<RootComponentProps> {
   rootComponent?:
     | React.ComponentClass<RootComponentProps, any>
     | React.FunctionComponent<RootComponentProps>;
-  loadRootComponent?: (props: RootComponentProps) => Promise<
+  loadRootComponent?: (
+    props: RootComponentProps
+  ) => Promise<
     | React.ComponentClass<RootComponentProps, any>
     | React.FunctionComponent<RootComponentProps>
   >;


### PR DESCRIPTION
Both the [documentation](https://single-spa.js.org/docs/ecosystem-react/) and [source code](https://github.com/single-spa/single-spa-react/blob/07e9272d83655fbe8e7d2269b143a897da4e5fa6/src/single-spa-react.js#L98) show that loadRootComponent method accepts one parameter which contains the single-spa props.