### PR TITLE
Add option to use a function as renderType

### DIFF
--- a/src/single-spa-react.js
+++ b/src/single-spa-react.js
@@ -203,20 +203,22 @@ function atLeastReact16(React) {
 }
 
 function reactDomRender({ opts, elementToRender, domElement }) {
+  const renderType =
+    typeof opts.renderType === "function" ? opts.renderType() : opts.renderType;
   if (
     [
       "createRoot",
       "unstable_createRoot",
       "createBlockingRoot",
       "unstable_createBlockingRoot",
-    ].indexOf(opts.renderType) >= 0
+    ].indexOf(renderType) >= 0
   ) {
-    const root = opts.ReactDOM[opts.renderType](domElement);
+    const root = opts.ReactDOM[renderType](domElement);
     root.render(elementToRender);
     return root;
   }
 
-  if (opts.renderType === "hydrate") {
+  if (renderType === "hydrate") {
     opts.ReactDOM.hydrate(elementToRender, domElement);
   } else {
     // default to this if 'renderType' is null or doesn't match the other options

--- a/types/single-spa-react.d.ts
+++ b/types/single-spa-react.d.ts
@@ -30,7 +30,15 @@ export interface SingleSpaReactOpts<RootComponentProps> {
     | "unstable_createRoot"
     | "createBlockingRoot"
     | "unstable_createBlockingRoot"
-    | "hydrate";
+    | "hydrate"
+    | "render"
+    | (() =>
+        | "createRoot"
+        | "unstable_createRoot"
+        | "createBlockingRoot"
+        | "unstable_createBlockingRoot"
+        | "hydrate"
+        | "render");
 }
 
 export interface ReactAppOrParcel<ExtraProps> {


### PR DESCRIPTION
Added the possibility to use `renderType` as a function. This enables apps to determine at runtime if they should use e.g., `hydrate` or `render` which does change for some applications (for example server-side rendered ones).
Setting `hydrate` as a constant for SSR apps produce a bug whenever the users entry-point to the site is not server-side rendered, as normal routing towards this app will not hit the server and the DOM will not have SSR content when the app bootstraps, which in turn produces an error message similar to this when reactdom.hydrate() is called (taken from isomorphic.microfrontends.app):
```
Warning: Expected server HTML to contain a matching <div> in <div>.
    in div (created by Pr)
    in Pr (created by _r)
    in t (created by t)
    in t (created by _r)
    in _r (created by rootComponent)
    in Ar (created by rootComponent)
    in ze (created by rootComponent)
    in O (created by rootComponent)
    in rootComponent
```

When used as a function, the renderType can be used for example like this, where it would let the developers decide when and if it should `hydrate` or `render`:
```
getRenderType = (): 'hydrate' | 'render' => {
    const shouldHydrate = document
        ?.getElementById('single-spa-application:@org/the-app')
        ?.hasChildNodes();
    return shouldHydrate ? 'hydrate' : 'render';
};

const lifecycles = singleSpaReact({
    React,
    ReactDOM,
    rootComponent,
    renderType: getRenderType,
```

Also added `render` as a possible ENUM value as stated in the docs https://single-spa.js.org/docs/ecosystem-react/#options and fixed a small typo