### PR TITLE
Move browserslist-config-single-spa to "dependencies". Resolves #133

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,9 @@
     "url": "https://github.com/joeldenning/single-spa-react/issues"
   },
   "homepage": "https://github.com/joeldenning/single-spa-react#readme",
+  "dependencies": {
+    "browserslist-config-single-spa": "^1.0.1"
+  },
   "devDependencies": {
     "@babel/core": "^7.15.5",
     "@babel/eslint-parser": "^7.15.7",
@@ -75,7 +78,6 @@
     "@testing-library/react": "^13.0.0-alpha.1",
     "@types/react": "^17.0.24",
     "@types/react-dom": "^17.0.9",
-    "browserslist-config-single-spa": "^1.0.1",
     "concurrently": "^6.2.1",
     "copyfiles": "^2.4.1",
     "cross-env": "^7.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ specifiers:
   tsd: ^0.17.0
   typescript: ^4.4.3
 
+dependencies:
+  browserslist-config-single-spa: 1.0.1
+
 devDependencies:
   '@babel/core': 7.15.5
   '@babel/eslint-parser': 7.15.7_@babel+core@7.15.5+eslint@7.32.0
@@ -53,7 +56,6 @@ devDependencies:
   '@testing-library/react': 13.0.0-alpha.1_c4f68f4d46be3ff534482e225bf1725e
   '@types/react': 17.0.24
   '@types/react-dom': 17.0.9
-  browserslist-config-single-spa: 1.0.1
   concurrently: 6.2.1
   copyfiles: 2.4.1
   cross-env: 7.0.3
@@ -2172,7 +2174,7 @@ packages:
 
   /browserslist-config-single-spa/1.0.1:
     resolution: {integrity: sha512-nqOxTbatv6FcdgBvUTuH4MuojMZwvskspz5Y4dmpVcKd0uaQY8KEl3iALWus16+AwPVe3BIerBNEgELyaHZcQg==}
-    dev: true
+    dev: false
 
   /browserslist/4.17.0:
     resolution: {integrity: sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==}


### PR DESCRIPTION
Resolves #133. I guess the browserslist configs are used not at a per-project level rather than just globally (which is how I thought of them), so moving our config from a devDependency to dependency makes sure it's available for all users of single-spa-react who are compiling with babel