### PR TITLE
Fix multi-parcel unmount resolving

### DIFF
--- a/src/single-spa-react.js
+++ b/src/single-spa-react.js
@@ -45,7 +45,7 @@ const defaultOpts = {
   domElements: {},
   renderResults: {},
   updateResolves: {},
-  unmountFinished: {},
+  unmountResolves: {},
 };
 
 export default function singleSpaReact(userOpts) {
@@ -153,7 +153,7 @@ function mount(opts, props) {
 
 function unmount(opts, props) {
   return new Promise((resolve) => {
-    opts.unmountFinished[props.name] = resolve;
+    opts.unmountResolves[props.name] = resolve;
 
     const root = opts.renderResults[props.name];
 
@@ -294,11 +294,9 @@ function getElementToRender(opts, props, mountFinished) {
         }
       },
       unmountFinished() {
-        if (opts.unmountFinished[props.name]) {
-          setTimeout(function () {
-            opts.unmountFinished[props.name]();
-            delete opts.unmountFinished[props.name];
-          });
+        if (opts.unmountResolves[props.name]) {
+          opts.unmountResolves[props.name]();
+          delete opts.unmountResolves[props.name];
         }
       },
     },

--- a/src/single-spa-react.js
+++ b/src/single-spa-react.js
@@ -45,6 +45,7 @@ const defaultOpts = {
   domElements: {},
   renderResults: {},
   updateResolves: {},
+  unmountFinished: {},
 };
 
 export default function singleSpaReact(userOpts) {
@@ -152,7 +153,7 @@ function mount(opts, props) {
 
 function unmount(opts, props) {
   return new Promise((resolve) => {
-    opts.unmountFinished = resolve;
+    opts.unmountFinished[props.name] = resolve;
 
     const root = opts.renderResults[props.name];
 
@@ -293,7 +294,12 @@ function getElementToRender(opts, props, mountFinished) {
         }
       },
       unmountFinished() {
-        setTimeout(opts.unmountFinished);
+        if (opts.unmountFinished[props.name]) {
+          setTimeout(function () {
+            opts.unmountFinished[props.name]();
+            delete opts.unmountFinished[props.name];
+          });
+        }
       },
     },
     elementToRender

--- a/src/single-spa-react.test.cjs
+++ b/src/single-spa-react.test.cjs
@@ -238,6 +238,55 @@ describe("single-spa-react", () => {
     );
   });
 
+  it(`correctly handles two parcels mounting and unmounting at the same time using the same configuration`, async () => {
+    let opts = {
+      React,
+      ReactDOMClient,
+      rootComponent,
+      suppressComponentDidCatchWarning: true,
+    };
+
+    let props1 = {
+      ...props,
+      name: "parcel-1",
+      domElement: document.createElement("div"),
+    };
+    let props2 = {
+      ...props,
+      name: "parcel-2",
+      domElement: document.createElement("div"),
+    };
+
+    const lifecycles = singleSpaReact(opts);
+    await lifecycles.bootstrap(props);
+
+    await act(async () => {
+      lifecycles.mount(props1);
+      lifecycles.mount(props2);
+    });
+
+    expect(props1.domElement.querySelector("button") instanceof Node).toBe(
+      true
+    );
+    expect(props2.domElement.querySelector("button") instanceof Node).toBe(
+      true
+    );
+
+    await act(async () => {
+      const promise1 = lifecycles.unmount(props1);
+      const promise2 = lifecycles.unmount(props2);
+      await expect(promise1).resolves.not.toThrow();
+      await expect(promise2).resolves.not.toThrow();
+    });
+
+    expect(props1.domElement.querySelector("button") instanceof Node).toBe(
+      false
+    );
+    expect(props2.domElement.querySelector("button") instanceof Node).toBe(
+      false
+    );
+  });
+
   it(`allows you to provide a domElementGetter as an opt`, async () => {
     let domEl = document.createElement("div");
 


### PR DESCRIPTION
The root object currently only allows a single `unmountFinished` promise at a time. Multiple parcels unmounting at the same time leads to most promises orphaned and not resolving, throwing console warnings.

This PR uses the parcel name to differentiate unmount promises.

Before:
![212499156-61685f3a-8d22-4295-8647-b58793db7ec0](https://user-images.githubusercontent.com/1402529/212499604-68edb1c4-82de-415b-a417-6b02e0ac09b7.gif)


After:
![212499535-538ece42-cb3d-45da-8f22-98ae931c95cd](https://user-images.githubusercontent.com/1402529/212499640-8bc908e7-3d88-488e-bf12-3779c28989bb.gif)



