### PR TITLE
Enable publishing

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,4 +38,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm exec auto shipit --dry-run # TODO: remove dry-run once its mostly working
+        run: pnpm exec auto shipit


### PR DESCRIPTION
After validating that this is [working as intended in CI](https://github.com/single-spa/single-spa-react/actions/runs/4237867778/jobs/7364303480), I'm enabling automated publishing through this PR. I'll also be marking it as a patch release and fixing the release notes to remove the mention to React 18 support that landed with v5.