### PR TITLE
fix: define package.json export

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "module": "lib/esm/single-spa-react.js",
   "type": "module",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "import": "./lib/esm/single-spa-react.js",
       "require": "./lib/cjs/single-spa-react.cjs"


### PR DESCRIPTION
compiling a react application using a rollup based plugin ([@vitejs/plugin-react](https://www.npmjs.com/package/@vitejs/plugin-react) in my case) will throw an error if package.json isn't exported. 

The only package failing in my usecase is `single-spa-react` I did test this change by manually adding this line to the package in the node_modules folder and compiling again. 

Example of such a export: https://github.com/facebook/react/blob/16d053d592673dd5565d85109f259371b23f87e8/packages/react-refresh/package.json#L24

Related Issue: https://github.com/uuidjs/uuid/issues/444