### PR TITLE
fix(#140,#168): Define package.json export

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,16 +5,6 @@
   "main": "lib/umd/single-spa-react.js",
   "module": "lib/esm/single-spa-react.js",
   "type": "module",
-  "exports": {
-    ".": {
-      "import": "./lib/esm/single-spa-react.js",
-      "require": "./lib/cjs/single-spa-react.cjs"
-    },
-    "./parcel": {
-      "import": "./lib/esm/parcel.js",
-      "require": "./lib/cjs/parcel.cjs"
-    }
-  },
   "files": [
     "lib",
     "parcel",


### PR DESCRIPTION
compiling a react application using a rollup based plugin ([@vitejs/plugin-react](https://www.npmjs.com/package/@vitejs/plugin-react) in my case) will throw an error if package.json isn't exported.

The only package failing in my usecase is single-spa-react I did test this change by manually adding this line to the package in the node_modules folder and compiling again.

Fixes: https://github.com/single-spa/single-spa-react/issues/140
https://github.com/single-spa/single-spa-react/issues/168