### PR TITLE
Do not log a warning when the `errorBoundaryClass` is provided

### DIFF
--- a/src/single-spa-react.js
+++ b/src/single-spa-react.js
@@ -116,7 +116,8 @@ function mount(opts, props) {
     if (
       !opts.suppressComponentDidCatchWarning &&
       atLeastReact16(opts.React) &&
-      !opts.errorBoundary
+      !opts.errorBoundary &&
+      !opts.errorBoundaryClass
     ) {
       if (!opts.rootComponent.prototype) {
         console.warn(


### PR DESCRIPTION
When a parcel is mounted it checks if `errorBoundary` is set or it implements the `componentDidCatch` function, if those are not available it will log a warning to the console. This warning is always logged when you use the `errorBoundaryClass` property. 

It is possible to work around this by setting `suppressComponentDidCatchWarning` but that feels a bit weird, so this PR fixes this issue by include an additional check if the `errorBoundaryClass` is set
