### PR TITLE
fix: exports types

### DIFF
--- a/.changeset/large-queens-poke.md
+++ b/.changeset/large-queens-poke.md
@@ -1,0 +1,5 @@
+---
+"single-spa-react": minor
+---
+
+Exports Typescript definitions using the exports property in package.json

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
       "require": "./lib/cjs/single-spa-react.cjs"
     },
     "./parcel": {
-      "types": "./types/parcel/index.d.ts",
+      "types": "./parcel/index.d.ts",
       "import": "./lib/esm/parcel.js",
       "require": "./lib/cjs/parcel.cjs"
     }

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/single-spa-react.d.ts",
       "import": "./lib/esm/single-spa-react.js",
       "require": "./lib/cjs/single-spa-react.cjs"
     },
     "./parcel": {
+      "types": "./types/parcel/index.d.ts",
       "import": "./lib/esm/parcel.js",
       "require": "./lib/cjs/parcel.cjs"
     }


### PR DESCRIPTION
Makes sure that the correct Typescript definitions are exported when export property in package.json is used.

Issue reference: https://github.com/single-spa/single-spa-react/issues/170