### PR TITLE
Fix node version for release workflow

### DIFF
--- a/.changeset/stale-readers-pull.md
+++ b/.changeset/stale-readers-pull.md
@@ -1,0 +1,5 @@
+---
+"single-spa-react": patch
+---
+
+Fix Node version for release workflow

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18
           cache: pnpm
 
       - name: Install dependencies


### PR DESCRIPTION
Fixing a small typo in the node version of the release workflow. This harmonizes the node version of the two workflows.