### PR TITLE
Swap L51 and L50

### DIFF
--- a/src/parcel.js
+++ b/src/parcel.js
@@ -47,8 +47,8 @@ export default class Parcel extends React.Component {
         this.props.appendTo.appendChild(domElement);
       }
       this.parcel = mountParcel(this.props.config, {
-        domElement,
         ...this.getParcelProps(),
+      	domElement,
       });
       this.parcel.mountPromise.then(this.props.parcelDidMount);
       return this.parcel.mountPromise;


### PR DESCRIPTION
Fixes #157 by swapping the lines L51 with L50.

Minimal repro repository:
https://github.com/SeverS/single-spa-react-repro
gh-pages : https://severs.github.io/single-spa-react-repro/

As you can see on gh-pages, the Button parcel works as expected when it's mounted inline but when you click it the modal which is using appendTo throws an error (check console)

