### PR TITLE
fix parcel appendTo

### DIFF
--- a/.changeset/angry-bottles-beam.md
+++ b/.changeset/angry-bottles-beam.md
@@ -1,0 +1,6 @@
+---
+"single-spa-react": patch
+---
+
+Swap lines L51 with L50 in parcel.js
+Fixes #157

--- a/src/parcel.js
+++ b/src/parcel.js
@@ -47,8 +47,8 @@ export default class Parcel extends React.Component {
         this.props.appendTo.appendChild(domElement);
       }
       this.parcel = mountParcel(this.props.config, {
-        domElement,
         ...this.getParcelProps(),
+        domElement,
       });
       this.parcel.mountPromise.then(this.props.parcelDidMount);
       return this.parcel.mountPromise;


### PR DESCRIPTION
Hi,
This pr fixes #157 by swapping the lines L50 with L51 in parcel.js

Minimal repro repository:
https://github.com/SeverS/single-spa-react-repro
gh-pages:
https://severs.github.io/single-spa-react-repro/

As you can see on gh-pages the button parcel works as expected when inline but when you click it it will throw an error in the console and the 'modal' will never be mounted.
